### PR TITLE
Storyille valmiit statukset backendissä

### DIFF
--- a/Dokumentit/sprint6backlog.md
+++ b/Dokumentit/sprint6backlog.md
@@ -3,7 +3,7 @@
 | user story | taski | työmäärä | status |
 | :-----------:|:-----------| :------| :------|
 | Storyille on olemassa valmiiksi määritellyt statukset (new, planned, done), joista voi valita | Tietokanta: Storyjen statuksille validointi? | 1 | done |
-| Storyille on olemassa valmiiksi määritellyt statukset (new, planned, done), joista voi valita | Back end: Storyjen virheellisestä statuksesta virheilmoitus | 2 | waiting |
+| Storyille on olemassa valmiiksi määritellyt statukset (new, planned, done), joista voi valita | Back end: Storyjen virheellisestä statuksesta virheilmoitus | 2 | done |
 | Storyille on olemassa valmiiksi määritellyt statukset (new, planned, done), joista voi valita | Front end: Storyn statuksen valinta dropdown menusta | 3 | waiting |
 | Taskeille on olemassa valmiiksi määritellyt statukset (waiting, doing, done), joista voi valita | Tietokanta: Taskien statuksille validointi? | 1 | waiting |
 | Taskeille on olemassa valmiiksi määritellyt statukset (waiting, doing, done), joista voi valita | Back end: Taskien virheellisestä statuksesta virheilmoitus | 2 | waiting |

--- a/Dokumentit/sprint6backlog.md
+++ b/Dokumentit/sprint6backlog.md
@@ -2,7 +2,7 @@
 
 | user story | taski | työmäärä | status |
 | :-----------:|:-----------| :------| :------|
-| Storyille on olemassa valmiiksi määritellyt statukset (new, planned, done), joista voi valita | Tietokanta: Storyjen statuksille validointi? | 1 | waiting |
+| Storyille on olemassa valmiiksi määritellyt statukset (new, planned, done), joista voi valita | Tietokanta: Storyjen statuksille validointi? | 1 | done |
 | Storyille on olemassa valmiiksi määritellyt statukset (new, planned, done), joista voi valita | Back end: Storyjen virheellisestä statuksesta virheilmoitus | 2 | waiting |
 | Storyille on olemassa valmiiksi määritellyt statukset (new, planned, done), joista voi valita | Front end: Storyn statuksen valinta dropdown menusta | 3 | waiting |
 | Taskeille on olemassa valmiiksi määritellyt statukset (waiting, doing, done), joista voi valita | Tietokanta: Taskien statuksille validointi? | 1 | waiting |

--- a/backend/controllers/userstories.js
+++ b/backend/controllers/userstories.js
@@ -40,6 +40,11 @@ userStoriesRouter.post('/', (request, response) => {
   if (status === '') {
     status = 'new'
   }
+  if (status !== 'new' || status !== 'planned' | status !== 'done') {
+    return response.status(400).json({ 
+      error: 'status must be new, planned, or done' 
+    })
+  }
 
 
   const newStoryObject = new UserStory({

--- a/backend/controllers/userstories.js
+++ b/backend/controllers/userstories.js
@@ -40,7 +40,7 @@ userStoriesRouter.post('/', (request, response) => {
   if (status === '') {
     status = 'new'
   }
-  if (status !== 'new' || status !== 'planned' | status !== 'done') {
+  if (status !== 'new' && status !== 'planned' && status !== 'done') {
     return response.status(400).json({ 
       error: 'status must be new, planned, or done' 
     })

--- a/backend/models/userstory.js
+++ b/backend/models/userstory.js
@@ -3,7 +3,13 @@ const mongoose = require('mongoose')
 const userStorySchema = new mongoose.Schema({
   story: String,
   date: Date,
-  status: String,
+  status: {
+    type: String,
+    enum: {
+      values: ['new', 'planned', 'done'],
+      message: '{VALUE} is not valid value for status'
+    },
+  },
   priority: Number,
   tasks: [
     {

--- a/backend/requests/add_new_userstory.rest
+++ b/backend/requests/add_new_userstory.rest
@@ -2,8 +2,8 @@ POST http://localhost:3001/api/userstories
 Content-Type: application/json
 
 {
-"story":"new story test 2",
+"story":"new story test 3",
 "priority":123,
-"status":"testi"
+"status":"new"
 }
 

--- a/backend/requests/add_new_userstory.rest
+++ b/backend/requests/add_new_userstory.rest
@@ -4,6 +4,6 @@ Content-Type: application/json
 {
 "story":"new story test 2",
 "priority":123,
-"status":"done"
+"status":"testi"
 }
 

--- a/backend/requests/add_new_userstory.rest
+++ b/backend/requests/add_new_userstory.rest
@@ -2,8 +2,8 @@ POST http://localhost:3001/api/userstories
 Content-Type: application/json
 
 {
-"story":"new story test",
+"story":"new story test 2",
 "priority":123,
-"status":"testi"
+"status":"done"
 }
 

--- a/backend/tests/sprintbacklog_api.test.js
+++ b/backend/tests/sprintbacklog_api.test.js
@@ -22,17 +22,17 @@ let demostories = [
   {
     story: 'As a user I want to create new user stories',
     priority: 1,
-    status: 'done'
+    status: 'new'
   },
   {
     story: 'As a user I want to modify user stories',
     priority: 2,
-    status: 'in progress'
+    status: 'new'
   },
   {
     story: 'As a user I want to delete user stories',
     priority: 99,
-    status: 'not started'
+    status: 'new'
   },
 ]
 
@@ -104,7 +104,7 @@ test('User story can be added to existing backlog', async () => {
   //console.log(allStories.body[3])
   expect(allBacklogs.body[0].userstories[0].story).toBe('As a user I want to create new user stories')
   expect(allBacklogs.body[0].userstories[0].priority).toBe(1)
-  expect(allBacklogs.body[0].userstories[0].status).toBe('done')
+  expect(allBacklogs.body[0].userstories[0].status).toBe('new')
   
 })
 

--- a/backend/tests/userstory_api.test.js
+++ b/backend/tests/userstory_api.test.js
@@ -9,17 +9,17 @@ let demodata = [
   {
     story: 'As a user I want to create new user stories',
     priority: 1,
-    status: 'done',
+    status: 'new',
   },
   {
     story: 'As a user I want to modify user stories',
     priority: 2,
-    status: 'in progress'
+    status: 'new'
   },
   {
     story: 'As a user I want to delete user stories',
     priority: 99,
-    status: 'not started'
+    status: 'new'
   },
 ]
 
@@ -105,11 +105,11 @@ test('all user stories are returned', async () => {
   expect(response.body).toHaveLength(demodata.length)
 })
 
-test('new user story with priority "123" and status "testing" can be added', async () => {
+test('new user story with priority "123" and status "new" can be added', async () => {
   const newUserStory = {
     story: 'Testing adding a new user story',
     priority: 123,
-    status: 'testing'
+    status: 'new'
   }
 
   await addNewUserStory(newUserStory)
@@ -119,7 +119,7 @@ test('new user story with priority "123" and status "testing" can be added', asy
   expect(allStories.body).toHaveLength(demodata.length + 1)
   expect(allStories.body[3].story).toBe('Testing adding a new user story')
   expect(allStories.body[3].priority).toBe(123)
-  expect(allStories.body[3].status).toBe('testing')
+  expect(allStories.body[3].status).toBe('new')
   
 })
 
@@ -147,13 +147,13 @@ test('User story status can be modified', async () => {
 
   
   const modifiedStatus = {
-    'status':'modified',
+    'status':'done',
   }
 
   await modifyUserStory(id, modifiedStatus)
   allStories = await getStories()
 
-  expect(allStories.body[0].status).toBe('modified')
+  expect(allStories.body[0].status).toBe('done')
 
 })
 
@@ -182,6 +182,25 @@ test('Task can be added to existing userstory', async () => {
   //console.log(allStories.body[3])
   expect(allStories.body[0].tasks[0].name).toBe('Task 1')
   expect(allStories.body[0].tasks[0].status).toBe('done')
+  
+})
+
+test('Userstory can not be added with invalid status', async () => {
+  const newUserStory = {
+    story: 'Testing adding a new user story',
+    priority: 123,
+    status: 'not valid'
+  }
+  await api
+    .post('/api/userstories')
+    .send(newUserStory)
+    .expect(400)
+    .expect('Content-Type', /application\/json/)
+
+
+  const allStories = await getStories()
+  expect(allStories.body).toHaveLength(demodata.length)
+  
   
 })
 


### PR DESCRIPTION
Storylle voi määrittää statuksen 'new', 'planned' tai 'done'. Backend testaukseen lisätty testi, joka varmistaa, että virheellisiä statuksia ei voi lisätä.

Validointi tapahtuu tietokannassa, mutta lisäsin myös testin controlleriin, jolloin virheellisellä statuksella olevia ei edes yritetä lisätä. Toteutusta kannattaa ehkä säätää vielä myöhemmin, jos tarpeen saada tarkempia virheilmoituksia tms.